### PR TITLE
Listen to pushes on master

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,7 +1,7 @@
 name: GitHub Pages
 
 on:
-  push: { branches: [ main ] }
+  push: { branches: [ master ] }
   pull_request: {}
 
 jobs:


### PR DESCRIPTION
The default branch for this repository is `master`, I don't know why the push event there was set to listen on the `main` branch. :(