### PR TITLE
Run deploy job on the master branch

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build ]
 
-    if: success() && github.ref == 'refs/head/master'
+    if: success() && github.ref == 'refs/heads/master'
 
     steps:
       - name: Download built pages


### PR DESCRIPTION
Sometimes I forget an `s` where there should be one. Sometimes I put an `s` where there shouldn't be one. It'll take a little bit of time for me to not only memorize where there should or should not be one, but also be able to catch that when reading over the code again.

Closes #5.