### PR TITLE
Use extended version of Hugo

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -16,6 +16,7 @@ jobs:
         uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: latest
+          extended: true
 
       - name: Generate static pages
         run: hugo --minify


### PR DESCRIPTION
Make the GitHub Pages workflow use the extended version of Hugo.

This way we can convert SASS/SCSS to CSS, among other things, mostly related to Hugo Pipes.

Closes #8.