### PR TITLE
Split Actions workflow into CI + CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,12 +1,12 @@
-name: GitHub Pages
+name: GitHub Pages CD
 
 on:
-  push: { branches: [ master ] }
-  pull_request: {}
+  push:
+    branches: [ master ]
 
 jobs:
-  build:
-    name: Build
+  deploy:
+    name: Hugo Deploy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files in the repository
@@ -20,25 +20,6 @@ jobs:
 
       - name: Generate static pages
         run: hugo --minify
-
-      - if: success()
-        name: Upload built pages
-        uses: actions/upload-artifact@v2
-        with:
-          name: built-site
-          path: public
-
-  deploy:
-    name: Deploy
-    runs-on: ubuntu-latest
-    needs: [ build ]
-
-    if: success() && github.ref == 'refs/heads/master'
-
-    steps:
-      - name: Download built pages
-        uses: actions/download-artifact@v2
-        with: { name: built-site }
 
       - name: Deploy to GitHub Pages (gh-pages)
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: GitHub Pages CI
+
+on: pull_request
+
+jobs:
+  build:
+    name: Hugo Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout files in the repository
+        uses: actions/checkout@v2
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: latest
+          extended: true
+
+      - name: Generate static pages
+        run: hugo --minify


### PR DESCRIPTION
Split the 'GitHub Pages' workflow into CI and CD workflows, respectively
named 'GitHub Pages CI' and 'GitHub Pages CD', both as a way to simplify
the deploy job declaration and to try and avoid having to upload build
artifacts just for another job to use.

Hopefully fixes #11.
