### PR TITLE
Bump checkout action version & enable LFS

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files in the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files in the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2


### PR DESCRIPTION
Bump the checkout action version from v2 to v3 and enable checkout of
LFS files. This is in hopes it'll be picked up by the gh-pages action
used in conjunction with the Hugo build.

Closes #18.
