### PR TITLE
Set the correct format for the timestamp

### DIFF
--- a/themes/base16/layouts/partials/elements/site-footer.html
+++ b/themes/base16/layouts/partials/elements/site-footer.html
@@ -1,3 +1,3 @@
 <footer>
-  <p id="timestamp">Published in {{ .PublishDate.Format "January 1, 2006" }}</p>
+  <p id="timestamp">Published in {{ .PublishDate.Format "January 2, 2006" }}</p>
 </footer>


### PR DESCRIPTION
Set the format for the timestamp to the one shown in the Hugo
documentation. Tested it locally and it seems to be working.

Closes #20.
