### PR TITLE
Scroll on horizontal overflow on code blocks

### DIFF
--- a/themes/base16/assets/style/critical.sass
+++ b/themes/base16/assets/style/critical.sass
@@ -124,6 +124,7 @@ article
     background: $bg-codeblock
     border-radius: 0.5em
     padding: 0.5em 1em
+    overflow-x: scroll
 
   p code
     background: $bg-codeblock


### PR DESCRIPTION
For code blocks (not snippets), sometimes the lines could be longer than what is
permissible for the parent element, leading to a broken layout. Instead, scroll
when there is overflowing content on the x axis.
