### PR TITLE
Add latest responsible commit to footer

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Checkout files in the repository
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           lfs: true
 
       - name: Setup Hugo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Checkout files in the repository
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           lfs: true
 
       - name: Setup Hugo

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,8 @@
-baseURL      = 'https://d3adb5.net/'
-title        = "d3adb5's personal website"
-languageCode = 'en-us'
-theme        = 'base16'
+baseURL       = 'https://d3adb5.net/'
+title         = "d3adb5's personal website"
+languageCode  = 'en-us'
+theme         = 'base16'
+enableGitInfo = true
 
 markup.goldmark.parser.attribute.block = true
 markup.goldmark.parser.attribute.title = true

--- a/themes/base16/assets/style/critical.sass
+++ b/themes/base16/assets/style/critical.sass
@@ -91,9 +91,13 @@ footer
   background: $bg-footer
   color: $fg-footer
 
+  display: grid
+  grid-template-columns: 50% 50%
+
+  p#timestamp, p#commit
+    margin: 0
   p#timestamp
     text-align: right
-    margin: 0
 
 article
   background: $bg-normal

--- a/themes/base16/layouts/partials/elements/site-footer.html
+++ b/themes/base16/layouts/partials/elements/site-footer.html
@@ -1,3 +1,4 @@
 <footer>
+  <p id="commit">{{ .GitInfo.AbbreviatedHash }}</p>
   <p id="timestamp">Published in {{ .PublishDate.Format "January 2, 2006" }}</p>
 </footer>

--- a/themes/base16/layouts/partials/elements/site-footer.html
+++ b/themes/base16/layouts/partials/elements/site-footer.html
@@ -1,4 +1,6 @@
 <footer>
-  <p id="commit">{{ .GitInfo.AbbreviatedHash }}</p>
+  {{ with .GitInfo }}
+  <p id="commit">{{ .AbbreviatedHash }}</p>
+  {{ end }}
   <p id="timestamp">Published in {{ .PublishDate.Format "January 2, 2006" }}</p>
 </footer>


### PR DESCRIPTION
Add the abbreviated hash for the last commit that changed the current page to
the footer, as a way to allow the reader to keep tabs on the latest changes that
were done to the page.

This does require knowledge of Git, but if the person reading wants to know when
the content was last updated --- and how --- they'll probably know it anyway.

The GitHub Actions workflows were updated to fetch the entire history, as the
`GitInfo` module (module?) is enabled in the site's config now.
