### PR TITLE
Linkify page commit hash in footer

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,9 @@ markup.goldmark.renderer.unsafe = true
 
 defaultContentLanguage = "en"
 
+[params]
+  repoUrl = "https://github.com/d3adb5/website"
+
 [languages]
   [languages.en]
     title = "d3adb5's personal website"

--- a/themes/base16/assets/style/critical.sass
+++ b/themes/base16/assets/style/critical.sass
@@ -95,6 +95,9 @@ footer
   grid-auto-flow: column
   grid-template-columns: minmax(0, 1fr)
 
+  a
+    color: $fg-footer
+
   p#timestamp, p#commit
     margin: 0
   p#timestamp

--- a/themes/base16/layouts/partials/elements/site-footer.html
+++ b/themes/base16/layouts/partials/elements/site-footer.html
@@ -1,6 +1,8 @@
 <footer>
   {{ with .GitInfo }}
-  <p id="commit">{{ .AbbreviatedHash }}</p>
+  <p id="commit"><a
+     href="{{ $.Site.Params.repoUrl }}/commit/{{ .Hash }}"
+  >{{ .AbbreviatedHash }}</a></p>
   {{ end }}
   <p id="timestamp">Published in {{ .PublishDate.Format "January 2, 2006" }}</p>
 </footer>


### PR DESCRIPTION
Linkify the commit hash that appears in the footer, so interested readers can
click on it and get taken to the latest change made to the page as it appears on
GitHub.
