### PR TITLE
style: add font fallbacks other than generics

### DIFF
--- a/themes/base16/assets/style/_settings.sass
+++ b/themes/base16/assets/style/_settings.sass
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;600&family=Source+Sans+Pro:ital,wght@0,400;0,600;1,400;1,600&display=swap')
 
-$common-font: 'Source Sans Pro', sans-serif
-$mono-font:   'Inconsolata', monospace
+$common-font: 'Source Sans Pro', 'Helvetica', 'Liberation Sans', 'Open Sans', sans-serif
+$mono-font:   'Inconsolata', 'DejaVu Sans Mono', 'Liberation Mono', monospace
 
 $common-background: transparent
 $common-padding: 1em


### PR DESCRIPTION
Add more font fallbacks than the generic sans-serif or monospace families. This way we can ensure common fonts that don't detract too much from the way Source Sans Pro looks can be used while it is being downloaded.
