### PR TITLE
style: reset line height for <pre>

### DIFF
--- a/themes/base16/assets/style/critical.sass
+++ b/themes/base16/assets/style/critical.sass
@@ -172,6 +172,7 @@ article
     border-radius: 0.5em
     padding: 0.5em 1em
     overflow-x: scroll
+    line-height: initial
 
   p code
     background: $bg-codeblock


### PR DESCRIPTION
Reset the line height for the preformatted (ironic) blocks. This way code doesn't take more space than it needs to, unnecessarily.
