### PR TITLE
chore: ignore resources dir & hugo build lock

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Generate static pages
         run: hugo --minify
+        env:
+          HUGO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to GitHub Pages (gh-pages)
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,5 @@ jobs:
 
       - name: Generate static pages
         run: hugo --minify
+        env:
+          HUGO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.hugo_build.lock
+/resources/

--- a/layouts/shortcodes/github.html
+++ b/layouts/shortcodes/github.html
@@ -1,6 +1,7 @@
+{{- $headers := dict "Authorization" (getenv "HUGO_GITHUB_TOKEN") -}}
 {{- $apiURL := .Get "path" | print "https://api.github.com/repos/" -}}
-{{- $repo := getJSON $apiURL -}}
-{{- $languages := getJSON $repo.languages_url -}}
+{{- $repo := getJSON $apiURL $headers -}}
+{{- $languages := getJSON $repo.languages_url $headers -}}
 
 {{- range $l, $c:= $languages }}
   {{- $languages = merge $languages (dict $l (dict "name" $l "count" $c)) -}}

--- a/layouts/shortcodes/project-card.html
+++ b/layouts/shortcodes/project-card.html
@@ -1,10 +1,11 @@
+{{- $headers := dict "Authorization" (getenv "HUGO_GITHUB_TOKEN") -}}
 {{- $project := .Get "project" -}}
 {{- $githubOwner := .Get "github" -}}
 {{- $githubAvatar := "" -}}
 
 {{- if $githubOwner }}
   {{- $apiURL := print "https://api.github.com/users/" $githubOwner -}}
-  {{- $githubOwner = getJSON $apiURL -}}
+  {{- $githubOwner = getJSON $apiURL $headers -}}
   {{- $githubAvatar = $githubOwner.avatar_url -}}
 {{- end }}
 


### PR DESCRIPTION
Ignore the resources directory and the .hugo_build.lock file at the root of the repository. These files are generated by hugo server during execution.
