### PR TITLE
style: lower the layout shift again

### DIFF
--- a/themes/base16/assets/style/flickity.sass
+++ b/themes/base16/assets/style/flickity.sass
@@ -5,6 +5,15 @@ section.js-flickity:not(.flickity-enabled)
   white-space: nowrap
   overflow-x: scroll
 
+  section.github-card
+    margin: 0 0.5em
+    white-space: normal
+
+    &:first-child
+      margin-left: 0
+    &:last-child
+      margin-right: 0
+
 section.flickity-enabled
   section.github-card
     margin: 0 0.5em

--- a/themes/base16/layouts/partials/metadata/page-meta.html
+++ b/themes/base16/layouts/partials/metadata/page-meta.html
@@ -4,6 +4,7 @@
     "style-src 'self' 'unsafe-inline'"
     "img-src *"
     "object-src 'none'"
+    "script-src 'self'"
     "base-uri 'self'"
 -}}
 


### PR DESCRIPTION
Add margins to the GitHub cards inside an unstyled Flickity container. This way they don't move around too much when the style for an initialized Flickity container is applied.

As an extra, the `script-src` directive was added to the CSP.
