### PR TITLE
feat: use hugo modules instead of versioning flickity

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,3 +25,14 @@ defaultContentLanguage = "en"
     [languages.pt-br.params]
       langName = "Português Brasileiro"
       flag = "🇧🇷"
+
+[module]
+
+  [[module.imports]]
+    path = "github.com/metafizzy/flickity"
+    [[module.imports.mounts]]
+      source = "dist/flickity.pkgd.min.js"
+      target = "static/scripts/flickity.min.js"
+    [[module.imports.mounts]]
+      source = "dist/flickity.min.css"
+      target = "static/style/flickity.min.css"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/d3adb5/website
+
+go 1.20
+
+require github.com/metafizzy/flickity v2.3.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/metafizzy/flickity v2.3.0+incompatible h1:fhgFtswA9BWcsGSisTbKzhOGUu6f8CgCap1AUKKZKgs=
+github.com/metafizzy/flickity v2.3.0+incompatible/go.mod h1:3af0f6bl0AoaouQGGT4vU92G1qFTxInk1DIHddXAtbY=

--- a/static/scripts/flickity.min.js
+++ b/static/scripts/flickity.min.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3aa6d58d974d052d6bad494e15bff103c518e148e59054c006564610b41103d2
-size 57654

--- a/static/style/flickity.min.css
+++ b/static/style/flickity.min.css
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8eef2ef6cf882d5e2e9167cb7c8b0ebbeb75b28a698835488733d149326fab4f
-size 1797


### PR DESCRIPTION
Use hugo modules to obtain the JavaScript files we need instead of versioning them in this repository unnecessarily.
