### PR TITLE
content: add extra section and move notes into it

### DIFF
--- a/content/extra/_index.md
+++ b/content/extra/_index.md
@@ -1,0 +1,29 @@
+---
+draft: false
+date: 2023-05-06
+
+title: Extra pages, failed experiments, etc.
+subtitle: Pages that don't fit anywhere else, or are undeserving of the spotlight
+
+navigation:
+  index: 3
+  right: false
+  title: Extra
+
+extensions: []
+---
+
+_Welcome to the extended menu!_ This is where pages that don't fit elsewhere on
+the website or have simply been forgotten end up. Small pages that don't deserve
+a spot on the main navigation bar, discontinued sections and forgotten drafts,
+pages can end up here for a variety of reasons. This doesn't mean they're bad,
+they just belong with the other misfits.
+
+## [Notes, a public notebook]({{< relref "notes" >}})
+
+**Dead as of 2023-05-06,** this section was supposed to contain some study notes
+and other useful information on things I was learning. I found it preferable to
+write articles to the [blog section][blog] instead. Nevertheless, the bit of
+text I wrote is still here if you want to read it.
+
+[blog]: {{< relref "/blog" >}}

--- a/content/extra/notes/_index.md
+++ b/content/extra/notes/_index.md
@@ -1,4 +1,6 @@
 ---
+type: notes
+
 draft: false
 date: 2022-09-27
 

--- a/content/extra/notes/kubernetes/_index.md
+++ b/content/extra/notes/kubernetes/_index.md
@@ -1,4 +1,6 @@
 ---
+type: notes
+
 draft: false
 date: 2022-09-27
 

--- a/content/extra/notes/kubernetes/kubernetes.md
+++ b/content/extra/notes/kubernetes/kubernetes.md
@@ -1,4 +1,6 @@
 ---
+type: notes
+
 draft: false
 date: 2022-09-27
 

--- a/content/extra/notes/prometheus/_index.md
+++ b/content/extra/notes/prometheus/_index.md
@@ -1,4 +1,6 @@
 ---
+type: notes
+
 draft: false
 date: 2022-10-15
 

--- a/content/extra/notes/prometheus/summary.md
+++ b/content/extra/notes/prometheus/summary.md
@@ -1,4 +1,6 @@
 ---
+type: notes
+
 draft: false
 date: 2022-10-15
 

--- a/themes/base16/archetypes/notes.md
+++ b/themes/base16/archetypes/notes.md
@@ -1,4 +1,6 @@
 ---
+type: notes
+
 draft: true
 date: {{ time.Format "2006-01-02" .Date }}
 

--- a/themes/base16/assets/style/critical.sass
+++ b/themes/base16/assets/style/critical.sass
@@ -253,6 +253,9 @@ article
       list-style-type: disc
       padding-left: 1.5em
 
+  &.extra-pages h2 ~ p
+    margin-left: 2em
+
 section.github-card
   display: inline-block
   max-width: 20em

--- a/themes/base16/layouts/extra/list.html
+++ b/themes/base16/layouts/extra/list.html
@@ -1,0 +1,22 @@
+{{ define "content" }}
+{{- $unmentioned := slice }}
+
+{{- range .Pages }}
+  {{- if strings.Contains $.Content .RelPermalink | not }}
+    {{- $unmentioned = $unmentioned | append . }}
+  {{- end }}
+{{- end }}
+
+<main role="main">
+  <article id="content" class="extra-pages">
+    {{ partial "elements/article-header.html" . }}
+    {{ .Content }}
+
+    {{ range $unmentioned }}
+    <h2><a href="{{ .RelPermalink }}">{{ .Params.navigation.title }}</a> - {{ .Title }}</h2>
+
+    <p>{{ .Summary }}</p>
+    {{ end }}
+  </article>
+</main>
+{{ end }}

--- a/themes/base16/layouts/notes/list.html
+++ b/themes/base16/layouts/notes/list.html
@@ -6,7 +6,7 @@
 
     <ul id="notebooks">
       {{- range .Pages.ByPublishDate.Reverse }}
-        {{- if eq .Parent.RelPermalink "/notes/" }}
+        {{- if eq .Parent.RelPermalink "/extra/notes/" }}
       <li class="notebook">{{ .Title }}
         {{- else }}
       <li class="notebook"><a href="{{ .Permalink }}">{{ .Title }}</a>


### PR DESCRIPTION
Add a section titled "Extra" for pages that don't fit into other categories but I'd like to have on the website anyway, as well as pages that don't deserve the spotlight of the main navbar for one reason or another.
