### PR TITLE
chore: use the canadian flag to represent english

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,8 +23,8 @@ languages:
   en:
     title: d3adb5's personal website
     params:
-      langName: English (US)
-      flag: 🇺🇸
+      langName: English
+      flag: 🇨🇦
   pt-br:
     title: website pessoal de d3adb5
     params:


### PR DESCRIPTION
Use the Canadian flag flag to represent the English language, and remove the '(US)' suffix from the English language name.
