### PR TITLE
fix: disable minification to fix blog fzf search

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -14,7 +14,8 @@ module.exports = {
         'unsized-images': 'off',
         'tap-targets': 'warn',
         'csp-xss': 'off',
-        'errors-in-console': 'off'
+        'errors-in-console': 'off',
+        'unminified-javascript': 'warn',
       }
     }
   }

--- a/themes/base16/layouts/blog/list.html
+++ b/themes/base16/layouts/blog/list.html
@@ -40,7 +40,7 @@
         "inputSelector"      "input#search-box"
         "resultsSelector"    "table#blog-index tbody"
         "identifierSelector" "td.title"
-      )) | resources.Minify
+      ))
     }}
     <script src="{{ $script.RelPermalink }}"></script>
   </article>


### PR DESCRIPTION
Stop minifying the FZF script. Apparently Hugo's minification is breaking the
script. This will be considered technical debt, and should be revisited in the
future.

Fixes #91.
