### PR TITLE
ci: avoid running lighthouse unnecessarily

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files in the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           lfs: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files in the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           lfs: true
@@ -63,7 +63,7 @@ jobs:
     if: ${{ needs.changes.outputs.pages == 'true' }}
     steps:
       - name: Checkout files in the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           node-version: 22
 
       - name: Download rendered files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: rendered-static-pages
           path: public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,24 @@ name: GitHub Pages CI
 on: pull_request
 
 jobs:
+  changes:
+    name: Changes Filter
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      pages: ${{ steps.filter.outputs.pages }}
+
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            pages:
+              - 'content/**'
+              - 'layouts/**'
+              - 'themes/**'
+
   build:
     name: Hugo Build
     runs-on: ubuntu-latest
@@ -41,7 +59,8 @@ jobs:
   lhci:
     name: Lighthouse
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs.pages == 'true' }}
     steps:
       - name: Checkout files in the repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
@@ -68,7 +68,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Download rendered files
         uses: actions/download-artifact@v4


### PR DESCRIPTION
- **ci: run lighthouse check only when pages change**
- **ci(deps): upgrade to actions/checkout v5**
- **ci(deps): upgrade to node 22**
- **ci(deps): upgrade to actions/download-artifact v5**
